### PR TITLE
providers-aws: Allow S3 Client to grab credentials from EC2 directly.

### DIFF
--- a/lib/webpacker_uploader/instance.rb
+++ b/lib/webpacker_uploader/instance.rb
@@ -13,16 +13,18 @@ class WebpackerUploader::Instance
     @manifest ||= WebpackerUploader::Manifest.new
   end
 
-  def upload!(provider)
-    manifest.assets.each do |name, path|
-      path = path[1..-1]
+  def upload!(provider, prefix: nil)
+    manifest.assets.each do |name, js_path|
+      path = js_path[1..-1]
+      remote_path = "#{prefix}/#{path}" unless prefix.nil?
+
       file_path = Rails.root.join("public", path)
 
       if name.end_with?(*IGNORE_EXTENSION)
         logger.info("Skipping: #{file_path}")
       else
         logger.info("Processing: #{file_path}")
-        provider.upload!(path, file_path, content_type_for(path)) unless name.end_with?(*IGNORE_EXTENSION)
+        provider.upload!(remote_path, file_path, content_type_for(path)) unless name.end_with?(*IGNORE_EXTENSION)
       end
     end
   end

--- a/lib/webpacker_uploader/providers/aws.rb
+++ b/lib/webpacker_uploader/providers/aws.rb
@@ -25,6 +25,8 @@ module WebpackerUploader
         def credentials(options)
           if options[:profile_name].present?
             ::Aws::SharedCredentials.new(profile_name: options[:profile_name])
+          elsif options.key?(:from_ec2) && options[:from_ec2]
+            ::Aws::InstanceProfileCredentials.new
           else
             ::Aws::Credentials.new(options[:access_key_id], options[:secret_access_key])
           end

--- a/lib/webpacker_uploader/providers/aws.rb
+++ b/lib/webpacker_uploader/providers/aws.rb
@@ -25,7 +25,7 @@ module WebpackerUploader
         def credentials(options)
           if options[:profile_name].present?
             ::Aws::SharedCredentials.new(profile_name: options[:profile_name])
-          elsif options.key?(:from_ec2) && options[:from_ec2]
+          elsif options.key?(:instance_profile) && options[:instance_profile]
             ::Aws::InstanceProfileCredentials.new
           else
             ::Aws::Credentials.new(options[:access_key_id], options[:secret_access_key])


### PR DESCRIPTION
👋 Hello! from the avlos team we are excited to use this gem. Pretty useful and simple 😬 .

In this PR,  we implement a basic option key that allow the EC2 instance to use the assigned role to upload files to the specified bucket in the options hash instead of relying in profiles or credentials. It is common for some EC2 instance to have a role that allow POST, PUT, MULTIPART UPLOAD operations

Let us know what you think.